### PR TITLE
fix: rework BottomAppBar scroll behavior to match TopAppBar

### DIFF
--- a/presentation/src/main/java/com/spiderbiggen/manga/presentation/components/bottomappbar/BottomAppBarState.kt
+++ b/presentation/src/main/java/com/spiderbiggen/manga/presentation/components/bottomappbar/BottomAppBarState.kt
@@ -2,12 +2,14 @@ package com.spiderbiggen.manga.presentation.components.bottomappbar
 
 import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.DecayAnimationSpec
+import androidx.compose.animation.rememberSplineBasedDecay
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.BottomAppBarDefaults
 import androidx.compose.material3.BottomAppBarScrollBehavior
 import androidx.compose.material3.BottomAppBarState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.rememberBottomAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -15,8 +17,6 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.unit.Velocity
-import androidx.compose.animation.rememberSplineBasedDecay
-import androidx.compose.material3.MaterialTheme
 
 @ExperimentalMaterial3Api
 @ExperimentalMaterial3ExpressiveApi

--- a/presentation/src/main/java/com/spiderbiggen/manga/presentation/components/bottomappbar/BottomAppBarState.kt
+++ b/presentation/src/main/java/com/spiderbiggen/manga/presentation/components/bottomappbar/BottomAppBarState.kt
@@ -15,37 +15,42 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.unit.Velocity
+import androidx.compose.animation.rememberSplineBasedDecay
+import androidx.compose.material3.MaterialTheme
 
 @ExperimentalMaterial3Api
 @ExperimentalMaterial3ExpressiveApi
 @Composable
-fun BottomAppBarDefaults.scrollAgainstContentBehavior(
+fun BottomAppBarDefaults.exitUntilEndScrollBehavior(
     state: BottomAppBarState = rememberBottomAppBarState(),
     canScroll: () -> Boolean = { true },
     lastItemIsVisible: () -> Boolean = { false },
-): BottomAppBarScrollBehavior = remember(state, canScroll, lastItemIsVisible) {
-    ExitAlwaysScrollBehavior(
+    snapAnimationSpec: AnimationSpec<Float>? = MaterialTheme.motionScheme.defaultEffectsSpec(),
+    flingAnimationSpec: DecayAnimationSpec<Float>? = rememberSplineBasedDecay(),
+): BottomAppBarScrollBehavior = remember(state, canScroll, lastItemIsVisible, snapAnimationSpec, flingAnimationSpec) {
+    ExitUntilEndScrollBehavior(
         state = state,
         canScroll = canScroll,
         lastItemIsVisible = lastItemIsVisible,
+        snapAnimationSpec = snapAnimationSpec,
+        flingAnimationSpec = flingAnimationSpec,
     )
 }
 
 @ExperimentalMaterial3Api
-private class ExitAlwaysScrollBehavior(
+private class ExitUntilEndScrollBehavior(
     override val state: BottomAppBarState,
     val canScroll: () -> Boolean = { true },
     val lastItemIsVisible: () -> Boolean = { false },
+    override val snapAnimationSpec: AnimationSpec<Float>?,
+    override val flingAnimationSpec: DecayAnimationSpec<Float>?,
 ) : BottomAppBarScrollBehavior {
-    override val flingAnimationSpec: DecayAnimationSpec<Float>? = null
-    override val snapAnimationSpec: AnimationSpec<Float>? = null
     override val isPinned: Boolean = false
 
     override var nestedScrollConnection = object : NestedScrollConnection {
         override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
-            if (!canScroll()) return Offset.Zero
-
-            if (lastItemIsVisible() && available.y < 0f) {
+            if (!canScroll() || available.y >= 0f) return Offset.Zero
+            if (lastItemIsVisible()) {
                 state.contentOffset -= available.y
                 state.heightOffset -= available.y
             } else {
@@ -60,8 +65,6 @@ private class ExitAlwaysScrollBehavior(
                 available.y > 0f &&
                 (state.heightOffset == 0f || state.heightOffset == state.heightOffsetLimit)
             ) {
-                // Reset the total content offset to zero when scrolling all the way down.
-                // This will eliminate some float precision inaccuracies.
                 state.contentOffset = 0f
             }
             return super.onPostFling(consumed, available)

--- a/presentation/src/main/java/com/spiderbiggen/manga/presentation/ui/manga/chapter/reader/MangaChapterReaderScreen.kt
+++ b/presentation/src/main/java/com/spiderbiggen/manga/presentation/ui/manga/chapter/reader/MangaChapterReaderScreen.kt
@@ -84,7 +84,7 @@ import com.spiderbiggen.manga.presentation.R.drawable.arrow_back
 import com.spiderbiggen.manga.presentation.components.FavoriteToggle
 import com.spiderbiggen.manga.presentation.components.PreloadImages
 import com.spiderbiggen.manga.presentation.components.bottomappbar.lastItemIsVisible
-import com.spiderbiggen.manga.presentation.components.bottomappbar.scrollAgainstContentBehavior
+import com.spiderbiggen.manga.presentation.components.bottomappbar.exitUntilEndScrollBehavior
 import com.spiderbiggen.manga.presentation.components.topappbar.MangaTopAppBar
 import com.spiderbiggen.manga.presentation.theme.MangaReaderTheme
 import kotlinx.collections.immutable.persistentListOf
@@ -129,7 +129,7 @@ fun MangaChapterReaderScreen(
     val topAppBarScrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(
         canScroll = { lazyListState.canScrollForward || lazyListState.canScrollBackward },
     )
-    val bottomAppBarScrollBehavior = BottomAppBarDefaults.scrollAgainstContentBehavior(
+    val bottomAppBarScrollBehavior = BottomAppBarDefaults.exitUntilEndScrollBehavior(
         canScroll = { lazyListState.canScrollForward || lazyListState.canScrollBackward },
         lastItemIsVisible = { lastItemIsVisible(lazyListState) },
     )

--- a/presentation/src/main/java/com/spiderbiggen/manga/presentation/ui/manga/chapter/reader/MangaChapterReaderScreen.kt
+++ b/presentation/src/main/java/com/spiderbiggen/manga/presentation/ui/manga/chapter/reader/MangaChapterReaderScreen.kt
@@ -83,8 +83,8 @@ import com.spiderbiggen.manga.presentation.R
 import com.spiderbiggen.manga.presentation.R.drawable.arrow_back
 import com.spiderbiggen.manga.presentation.components.FavoriteToggle
 import com.spiderbiggen.manga.presentation.components.PreloadImages
-import com.spiderbiggen.manga.presentation.components.bottomappbar.lastItemIsVisible
 import com.spiderbiggen.manga.presentation.components.bottomappbar.exitUntilEndScrollBehavior
+import com.spiderbiggen.manga.presentation.components.bottomappbar.lastItemIsVisible
 import com.spiderbiggen.manga.presentation.components.topappbar.MangaTopAppBar
 import com.spiderbiggen.manga.presentation.theme.MangaReaderTheme
 import kotlinx.collections.immutable.persistentListOf


### PR DESCRIPTION
## Summary

- Replaces the old `scrollAgainstContentBehavior` with `exitUntilEndScrollBehavior`, matching the naming convention of `TopAppBarDefaults.exitUntilCollapsedScrollBehavior`
- Bottom bar now exits (hides) on downward scroll and does **not** reappear on upward scroll
- When the last item in the list is visible, downward scroll drives the bar back into view (scroll-linked reveal)
- Adds `snapAnimationSpec` and `flingAnimationSpec` to match the top bar's snap/fling feel

## Test plan

- [ ] Scroll down through a chapter — bottom bar hides
- [ ] Scroll back up — bottom bar stays hidden
- [ ] Scroll to the end of the chapter — bottom bar reappears as the last item becomes visible
- [ ] Tap the screen to toggle bars — both top and bottom animate in/out together