### PR TITLE
feat(ci): add stabilityCheck tasks to CI workflow matrix

### DIFF
--- a/.github/workflows/ci_check.yaml
+++ b/.github/workflows/ci_check.yaml
@@ -43,7 +43,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        task: [ test, lint, spotlessCheck, detekt ]
+        task:
+          - 'test'
+          - 'lint'
+          - 'spotlessCheck'
+          - 'detekt'
+          - 'app:stabilityCheck'
+          - 'presentation:stabilityCheck'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci_check.yaml
+++ b/.github/workflows/ci_check.yaml
@@ -20,6 +20,7 @@ concurrency:
 # Where it will run
 jobs:
   build:
+    name: Build Debug
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -43,13 +44,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        task:
-          - 'test'
-          - 'lint'
-          - 'spotlessCheck'
-          - 'detekt'
-          - 'app:stabilityCheck'
-          - 'presentation:stabilityCheck'
+        include:
+          - task: test
+            gradle-tasks: test
+          - task: lint
+            gradle-tasks: lint
+          - task: spotlessCheck
+            gradle-tasks: spotlessCheck
+          - task: detekt
+            gradle-tasks: detekt
+          - task: stability
+            gradle-tasks: app:stabilityCheck presentation:stabilityCheck
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -62,17 +67,20 @@ jobs:
           SIGNING_ALIAS: ${{ secrets.SIGNING_ALIAS }}
 
       - name: Run ${{ matrix.task }}
-        run: ./gradlew ${{ matrix.task }}
+        run: ./gradlew ${{ matrix.gradle-tasks }}
 
       - name: Upload ${{ matrix.task }} reports
         uses: actions/upload-artifact@v7
         with:
           name: reports-${{ matrix.task }}
-          path: ./**/build/reports
+          path: |
+            ./**/build/reports
+            ./**/build/test-results
         if: always()
 
   sonar:
-    needs: [ checks ]
+    name: SonarQube Analysis
+    needs: [ build, checks ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
This Pull Request updates the CI workflow to improve task handling, add a new stability check task, and restructure how tasks and build reports are managed.
- Added a descriptive name for the "build" job (Build Debug) and renamed the "sonar" job for clarity (SonarQube Analysis).
- Refactored the CI matrix strategy. It now uses a more structured include block, assigning specific Gradle tasks to each job.
- Introduced a new stability check task (stability) for additional checks on app and presentation modules.
- Improved artifact upload to include both build reports and test results.